### PR TITLE
remove shebang argument

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash -e
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
the shebang line `#!/usr/bin/env bash -e` lead to

    /usr/bin/env: "bash -e": No such file or directory

additional parameters might lead to portability problems, as described here https://en.wikipedia.org/wiki/Shebang_(Unix)#Portability

The second command line in the script, `set -e`, has anyway the same effect as `bash -e`.