### PR TITLE
Fetch AWS config from ec2metadata if on an ec2 instance

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,21 +3,34 @@ package main
 import (
 	"os"
 
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 	"github.com/aws/aws-sdk-go/aws"
 )
 
 func RetrieveSecret(variableName string) {
+
+	// AWS Go SDK does not currently support automatic fetching of region from ec2metadata
+	// Create metaSession to fetch the region and supply it to the regular Session
+
+	metaSession, _ := session.NewSession()
+	metaClient := ec2metadata.New(metaSession)
+	region, _ := metaClient.Region()
+
+	conf := aws.NewConfig().WithRegion(region)
+
 	// All clients require a Session. The Session provides the client with
 	// shared configuration such as region, endpoint, and credentials. A
 	// Session should be shared where possible to take advantage of
 	// configuration and credential caching. See the session package for
 	// more information.
+
 	sess, err := session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,
+		Config: *conf,
 	})
-	if err != nil { // resp is now filled
+	if err != nil {
 		printAndExit(err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -3,35 +3,34 @@ package main
 import (
 	"os"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
-	"github.com/aws/aws-sdk-go/aws"
 )
 
 func RetrieveSecret(variableName string) {
-
-	// AWS Go SDK does not currently support automatic fetching of region from ec2metadata
-	// Create metaSession to fetch the region and supply it to the regular Session
-
-	metaSession, _ := session.NewSession()
-	metaClient := ec2metadata.New(metaSession)
-	region, _ := metaClient.Region()
-
-	conf := aws.NewConfig().WithRegion(region)
-
 	// All clients require a Session. The Session provides the client with
 	// shared configuration such as region, endpoint, and credentials. A
 	// Session should be shared where possible to take advantage of
 	// configuration and credential caching. See the session package for
 	// more information.
-
 	sess, err := session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,
-		Config: *conf,
 	})
 	if err != nil {
 		printAndExit(err)
+	}
+
+	// AWS Go SDK does not currently support automatic fetching of region from ec2metadata.
+	// If the region could not be found in an environment variable or a shared config file,
+	// create metaSession to fetch the ec2 instance region and pass to the regular Session.
+	if *sess.Config.Region == "" {
+		metaSession, _ := session.NewSession()
+		metaClient := ec2metadata.New(metaSession)
+		region, _ := metaClient.Region()
+
+		sess.Config.Region = aws.String(region)
 	}
 
 	// Create a new instance of the service's client with a Session.

--- a/main.go
+++ b/main.go
@@ -26,11 +26,21 @@ func RetrieveSecret(variableName string) {
 	// If the region could not be found in an environment variable or a shared config file,
 	// create metaSession to fetch the ec2 instance region and pass to the regular Session.
 	if *sess.Config.Region == "" {
-		metaSession, _ := session.NewSession()
-		metaClient := ec2metadata.New(metaSession)
-		region, _ := metaClient.Region()
+		metaSession, err := session.NewSession()
+		if err != nil {
+			printAndExit(err)
+		}
 
-		sess.Config.Region = aws.String(region)
+		metaClient := ec2metadata.New(metaSession)
+		// If running on an EC2 instance, the metaClient will be available and we can set the region to match the instance
+		// If not on an EC2 instance, the region will remain blank and AWS returns a "MissingRegion: ..." error
+		if metaClient.Available() {
+			if region, err := metaClient.Region(); err == nil {
+				sess.Config.Region = aws.String(region)
+			} else {
+				printAndExit(err)
+			}
+		}
 	}
 
 	// Create a new instance of the service's client with a Session.


### PR DESCRIPTION
Not the prettiest solution, but there doesn't appear to be native support for fetching the region from the ec2 instance it's running on. 

Relevant feature request in aws-go-sdk: https://github.com/aws/aws-sdk-go/issues/1103