### PR TITLE
Adding alpine-linux release and build refactoring

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,34 +1,34 @@
 #!/bin/bash
 
-# Platforms to build: https://golang.org/doc/install/source#environment
-PLATFORMS=(
-  'darwin:amd64'     # MacOS
-  # 'dragonfly:amd64'  # Dragonfly https://www.dragonflybsd.org/
-  'freebsd:amd64'
-  # 'linux:386'
-  'linux:amd64'
-  # 'linux:arm'
-  # 'linux:arm64'
-  'netbsd:amd64'
-  'openbsd:amd64'
-  'solaris:amd64'
-  # 'windows:386'
-  'windows:amd64'
+APP='summon-aws-secrets'
+PKGDIR='output'
+OSES=(
+  'darwin'
+  'freebsd'
+  'linux'
+  'netbsd'
+  'openbsd'
+  'solaris'
+  'windows'
 )
+GOARCH='amd64'
 
-echo "Creating summon-aws-secrets binaries in output/"
-docker-compose build --pull builder
-
-for platform in "${PLATFORMS[@]}"; do
-  GOOS=${platform%%:*}
-  GOARCH=${platform#*:}
-
+for GOOS in "${OSES[@]}"; do
+  echo "Building $GOOS-$GOARCH binary"
   echo "-----"
-  echo "GOOS=$GOOS, GOARCH=$GOARCH"
-  echo "....."
 
-  docker-compose run --rm \
-    -e GOOS=$GOOS -e GOARCH=$GOARCH \
-    builder \
-      build -v -o output/summon-aws-secrets-$GOOS-$GOARCH
+  docker run --rm \
+    -v "$PWD:/go/src/$APP" -w "/go/src/$APP" \
+    -e "GOOS=$GOOS" -e "GOARCH=$GOARCH" \
+    golang:1.9 \
+    go build -v -o $PKGDIR/$APP-$GOOS-$GOARCH
 done
+
+echo "Building linux-alpine binary"
+echo "-----"
+
+docker run --rm \
+  -v "$PWD:/go/src/$APP" -w "/go/src/$APP" \
+  -e "GOOS=linux" -e "GOARCH=$GOARCH" \
+  golang:1.9-alpine \
+  go build -v -o $PKGDIR/$APP-linux-alpine-amd64

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,5 @@
 version: '2'
 services:
-  builder:
-    build: .
-    image: summon-aws-secrets-builder
-    entrypoint: /usr/local/go/bin/go
-    command: build -v
-    volumes:
-      - ./output:/go/src/github.com/cyberark/summon-aws-secrets/output
-    environment:
-      GOOS:
-      GOARCH:
-
   tester:
     build: .
     image: summon-aws-secrets-tester


### PR DESCRIPTION
This commit updates the build process to follow the more recent pattern
introduced in summon-s3. In addition, the glibc requirements are fixed
for alpine linux by providing a specific release for it.

I ran through a cycle with the build / test / package scripts, and confirmed all working. I'm also actively using the alpine version in new project's container as of today. 