### PR TITLE
fix: handle non string JSON values

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"strings"
+	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
@@ -112,11 +113,14 @@ func printAndExit(err error) {
 }
 
 func getValueByKey(keyName string, secretBytes []byte) (secret []byte, err error) {
-	var secrets map[string]string
+	var secrets map[string]interface{}
+	var secretValue string
 
 	if err := json.Unmarshal(secretBytes, &secrets); err != nil {
 		return nil, err
 	}
 
-	return []byte(secrets[keyName]), nil
+	secretValue = fmt.Sprint(secrets[keyName])
+
+	return []byte(secretValue), nil
 }

--- a/package_test.go
+++ b/package_test.go
@@ -39,22 +39,24 @@ func TestPackage(t *testing.T) {
 					So(stderr.String(), ShouldStartWith, "A variable ID or version flag must be given as the first and only argument!")
 				})
 			})
+		})
+	})
+}
 
-			Convey("Given summon-aws-secrets is retrieving a secret with key value format", func() {
-				secret := `{ "username": "USERNAME", "password": "PASSWORD", "port": 8000 }`
+func Test_getValueByKey(t *testing.T) {
+	Convey("Given a valid JSON format stored secret", t, func() {
+		secret := `{ "username": "USERNAME", "password": "PASSWORD", "port": 8000 }`
 
-				Convey("Returns with the value of the key", func() {
-					stdout, err := getValueByKey("username", []byte(secret))
-					So(err, ShouldBeNil)
-					So(string(stdout), ShouldEqual, "USERNAME")
-				})
+		Convey("Returns the value of the key", func() {
+			stdout, err := getValueByKey("username", []byte(secret))
+			So(err, ShouldBeNil)
+			So(string(stdout), ShouldEqual, "USERNAME")
+		})
 
-				Convey("Always returns as a string", func() {
-					stdout, err := getValueByKey("port", []byte(secret))
-					So(err, ShouldBeNil)
-					So(string(stdout), ShouldEqual, "8000")
-				})
-			})
+		Convey("Always returns as a string", func() {
+			stdout, err := getValueByKey("port", []byte(secret))
+			So(err, ShouldBeNil)
+			So(string(stdout), ShouldEqual, "8000")
 		})
 	})
 }

--- a/package_test.go
+++ b/package_test.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"bytes"
-	. "github.com/smartystreets/goconvey/convey"
 	"os"
 	"os/exec"
 	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 func RunCommand(name string, arg ...string) (bytes.Buffer, bytes.Buffer, error) {
@@ -29,6 +30,24 @@ func WithoutArgs() {
 	})
 }
 
+func WithKeyPairValues() {
+	Convey("Given summon-aws-secrets is retrieving a secret with key value format", func() {
+		secret := "{\"username\":\"USERNAME\",\"password\":\"PASSWORD\",\"port\":8000}"
+
+		Convey("Returns with the value of the key", func() {
+			stdout, err := getValueByKey("username", []byte(secret))
+			So(err, ShouldBeNil)
+			So(string(stdout), ShouldStartWith, "USERNAME")
+		})
+
+		Convey("Always returns as a string", func() {
+			stdout, err := getValueByKey("port", []byte(secret))
+			So(err, ShouldBeNil)
+			So(string(stdout), ShouldStartWith, "8000")
+		})
+	})
+}
+
 const PackageName = "summon-aws-secrets"
 
 func TestPackage(t *testing.T) {
@@ -42,6 +61,7 @@ func TestPackage(t *testing.T) {
 			os.Setenv("PATH", Path)
 
 			WithoutArgs()
+			WithKeyPairValues()
 		})
 	})
 }

--- a/package_test.go
+++ b/package_test.go
@@ -19,35 +19,6 @@ func RunCommand(name string, arg ...string) (bytes.Buffer, bytes.Buffer, error) 
 	return stdout, stderr, err
 }
 
-func WithoutArgs() {
-	Convey("Given summon-aws-secrets is run with no arguments", func() {
-		_, stderr, err := RunCommand(PackageName)
-
-		Convey("Returns with error", func() {
-			So(err, ShouldNotBeNil)
-			So(stderr.String(), ShouldStartWith, "A variable ID or version flag must be given as the first and only argument!")
-		})
-	})
-}
-
-func WithKeyPairValues() {
-	Convey("Given summon-aws-secrets is retrieving a secret with key value format", func() {
-		secret := "{\"username\":\"USERNAME\",\"password\":\"PASSWORD\",\"port\":8000}"
-
-		Convey("Returns with the value of the key", func() {
-			stdout, err := getValueByKey("username", []byte(secret))
-			So(err, ShouldBeNil)
-			So(string(stdout), ShouldStartWith, "USERNAME")
-		})
-
-		Convey("Always returns as a string", func() {
-			stdout, err := getValueByKey("port", []byte(secret))
-			So(err, ShouldBeNil)
-			So(string(stdout), ShouldStartWith, "8000")
-		})
-	})
-}
-
 const PackageName = "summon-aws-secrets"
 
 func TestPackage(t *testing.T) {
@@ -60,8 +31,30 @@ func TestPackage(t *testing.T) {
 			defer e.RestoreEnv()
 			os.Setenv("PATH", Path)
 
-			WithoutArgs()
-			WithKeyPairValues()
+			Convey("Given summon-aws-secrets is run with no arguments", func() {
+				_, stderr, err := RunCommand(PackageName)
+
+				Convey("Returns with error", func() {
+					So(err, ShouldNotBeNil)
+					So(stderr.String(), ShouldStartWith, "A variable ID or version flag must be given as the first and only argument!")
+				})
+			})
+
+			Convey("Given summon-aws-secrets is retrieving a secret with key value format", func() {
+				secret := `{ "username": "USERNAME", "password": "PASSWORD", "port": 8000 }`
+
+				Convey("Returns with the value of the key", func() {
+					stdout, err := getValueByKey("username", []byte(secret))
+					So(err, ShouldBeNil)
+					So(string(stdout), ShouldEqual, "USERNAME")
+				})
+
+				Convey("Always returns as a string", func() {
+					stdout, err := getValueByKey("port", []byte(secret))
+					So(err, ShouldBeNil)
+					So(string(stdout), ShouldEqual, "8000")
+				})
+			})
 		})
 	})
 }


### PR DESCRIPTION
By default *Credentials for RDS database* secret type includes the port, which isn't a string. It raises the error: `json: cannot unmarshal number into Go value of type string`.

My proposal is to handle the values as interface and convert only the output.