### PR TITLE
Improved robustness of the installation script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Upgraded build/test images to use Golang 1.13 instead of 1.11.
   [cyberark/summon-aws-secrets#27](https://github.com/cyberark/summon-aws-secrets/issues/27)
 
+### Fixed
+- Made installer script more robust to target environments.
+  [cyberark/summon-aws-secrets#16](https://github.com/cyberark/summon-aws-secrets/issues/16)
+
 ## [0.3.0] - 2019-03-06
 ### Added
 - Converted to go modules
@@ -27,6 +31,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/cyberark/conjur-api-go/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/cyberark/conjur-api-go/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/cyberark/conjur-api-go/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/cyberark/conjur-api-go/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/cyberark/conjur-api-go/compare/v0.1.0...v0.2.0

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ curl -sSL https://raw.githubusercontent.com/cyberark/summon-aws-secrets/master/i
 
 Otherwise, download the [latest release](https://github.com/cyberark/summon-aws-secrets/releases) and extract it to the directory `/usr/local/lib/summon`.
 
+**If you are running an Alpine-based system, you will need to add libc6 compatiblity package (`apk add libc6-compat`)!**
+
 ## Variable IDs
 Variable IDs are used as identifiers for fetching Secrets. These are made up of a secret name (required) and secret key path (optional). 
 

--- a/install.sh
+++ b/install.sh
@@ -1,44 +1,71 @@
 #!/usr/bin/env bash
 
 set -e
+set -o pipefail
+
+error() {
+  echo "ERROR: $@" 1>&2
+  echo "Exiting installer" 1>&2
+  exit 1
+}
 
 ARCH=`uname -m`
 
 if [ "${ARCH}" != "x86_64" ]; then
-  echo "summon-aws-secrets only works on 64-bit systems"
-  echo "exiting installer"
-  exit 1
+  error "summon-aws-secrets only works on 64-bit systems"
 fi
 
 DISTRO=`uname | tr "[:upper:]" "[:lower:]"`
 
 if [ "${DISTRO}" != "linux" ] && [ "${DISTRO}" != "darwin"  ]; then
-  echo "This installer only supports Linux and OSX"
-  echo "exiting installer"
-  exit 1
+  error "This installer only supports Linux and OSX"
 fi
 
-if test "x$TMPDIR" = "x"; then
+if [ ! -z "$TMPDIR" ]; then
   tmp="/tmp"
 else
   tmp=$TMPDIR
 fi
-# secure-ish temp dir creation without having mktemp available (DDoS-able but not expliotable)
+# secure-ish temp dir creation without having mktemp available (DDoS-able but not exploitable)
 tmp_dir="$tmp/install.sh.$$"
 (umask 077 && mkdir $tmp_dir) || exit 1
 
 # do_download URL DIR
-function do_download(){
+do_download() {
   echo "Downloading $1"
-  if   [[ $(type -t wget) ]]; then wget -q -c -O "$2" "$1" >/dev/null
-  elif [[ $(type -t curl) ]]; then curl -sSL -o "$2" "$1"
+  if [[ $(command -v wget) ]]; then
+    wget -q -O "$2" "$1" >/dev/null
+  elif [[ $(command -v curl) ]]; then
+    curl --fail -sSL -o "$2" "$1" &>/dev/null || true
   else
     error "Could not find wget or curl"
-    return 1
+    exit 1
   fi
 }
 
-LATEST_VERSION=$(curl -s https://api.github.com/repos/cyberark/summon-aws-secrets/releases/latest | grep -o '"tag_name": "[^"]*' | grep -o '[^"]*$')
+# get_latest_version
+get_latest_version() {
+  local LATEST_VERSION_URL="https://api.github.com/repos/cyberark/summon-aws-secrets/releases/latest"
+  local latest_payload
+
+  if [[ $(command -v wget) ]]; then
+    latest_payload=$(wget -q -O - "$LATEST_VERSION_URL")
+  elif [[ $(command -v curl) ]]; then
+    latest_payload=$(curl --fail -sSL "$LATEST_VERSION_URL")
+  else
+    error "Could not find wget or curl"
+    exit 1
+  fi
+
+  echo "$latest_payload" | # Get latest release from GitHub api
+    grep '"tag_name":' | # Get tag line
+    sed -E 's/.*"([^"]+)".*/\1/' # Pluck JSON value
+}
+
+LATEST_VERSION=$(get_latest_version)
+
+echo "Using version number: $LATEST_VERSION"
+
 BASEURL="https://github.com/cyberark/summon-aws-secrets/releases/download/"
 URL=${BASEURL}"${LATEST_VERSION}/summon-aws-secrets-${DISTRO}-amd64.tar.gz"
 
@@ -47,8 +74,13 @@ do_download ${URL} ${ZIP_PATH}
 
 echo "Installing summon-aws-secrets ${LATEST_VERSION} into /usr/local/lib/summon"
 
-sudo mkdir -p /usr/local/lib/summon
-sudo tar -C /usr/local/lib/summon -zxvf ${ZIP_PATH}
+if sudo -h >/dev/null 2>&1; then
+  sudo mkdir -p /usr/local/lib/summon
+  sudo tar -C /usr/local/lib/summon -o -zxvf ${ZIP_PATH} >/dev/null
+else
+  mkdir -p /usr/local/lib/summon
+  tar -C /usr/local/lib/summon -o -zxvf ${ZIP_PATH} >/dev/null
+fi
 
 echo "Success!"
 echo "Run /usr/local/lib/summon/summon-aws-secrets for usage"


### PR DESCRIPTION
Old script was unable to handle either issues with `sudo` not being
present nor handle systems that only have curl installed. We also now
properly use the installer owner as the executable file's owner.

### What ticket does this PR close?
Connected to #16 

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation