### PR TITLE
Fix temp directory usage for install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -21,11 +21,11 @@ if [ "${DISTRO}" != "linux" ] && [ "${DISTRO}" != "darwin"  ]; then
   error "This installer only supports Linux and OSX"
 fi
 
+tmp="/tmp"
 if [ ! -z "$TMPDIR" ]; then
-  tmp="/tmp"
-else
   tmp=$TMPDIR
 fi
+
 # secure-ish temp dir creation without having mktemp available (DDoS-able but not exploitable)
 tmp_dir="$tmp/install.sh.$$"
 (umask 077 && mkdir $tmp_dir) || exit 1


### PR DESCRIPTION
The condition for selecting what temp directory to use was inverted from
what it should be. This change fixes this problem.

### What ticket does this PR close?
N/A

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation