### PR TITLE
Added a build for Apple Silicon

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,7 +5,8 @@ before:
   hooks: []
 
 builds:
-  - binary: summon-aws-secrets
+  - id: summon-aws-secrets
+    binary: summon-aws-secrets
     env:
       - CGO_ENABLED=0
     goos:
@@ -19,6 +20,16 @@ builds:
     goarch:
       - amd64
     ldflags: []
+  - id: summon-aws-secrets-arm
+    binary: summon-aws-secrets
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - 'darwin'       # MacOS
+    goarch:
+      - arm64
+    ldflags: []
+
 
 archives:
   - id: summon-aws-secrets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Added a build for Apple Silicon [cyberark/summon-aws-secrets#55](https://github.com/cyberark/summon-aws-secrets/issues/55)
 
 ## [0.4.0] - 2020-09-11
 ### Changed


### PR DESCRIPTION
Based on the changes to the main summon `.goreleaser.yml` file, I've added the same changes to this configuration. 

I was able to do a `./bin/build.sh` locally, and could manually copy over the result to `/usr/local/lib/summon` which seems to work.

Note, I've never done any work with either Go or GoReleaser, so this might be the wrong approach. So feel free to suggest a completely different approach to solve the issue of adding support for Apple Silicon.

### Desired Outcome

A release for Apple Silicon powered macOS computers to run is created along side all of the existing releases.

### Implemented Changes

* Took the same approach to modifying the `.goreleaser.yml` in https://github.com/cyberark/summon/commit/d8e955c7e34c65339a438a9c4626c8231c468fb3

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
