### PR TITLE
Updating Goreleaser to the latest version to support new Apple Silicon

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - .:/summon-aws-secrets
 
   goreleaser:
-    image: registry.tld/goreleaser
+    image: goreleaser/goreleaser:latest
     volumes:
       - .:/summon-aws-secrets
     working_dir: /summon-aws-secrets


### PR DESCRIPTION
### Desired Outcome

Goreleaser should support the darwin arm64 images.

### Implemented Changes

The current version of Goreleaser that is used does not support the new hardware.
This updated the Goreleaser version so we can add the arm64 images.

### Connected Issue/Story

Is needed for #55

CyberArk internal issue link: [insert issue ID]()

### Definition of Done

- [x] Goreleaser is updated to latest and all the previous builds still work.

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
