### PR TITLE
Fix changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
 - Added a build for Apple Silicon [cyberark/summon-aws-secrets#55](https://github.com/cyberark/summon-aws-secrets/issues/55)
 
 ## [0.4.0] - 2020-09-11


### PR DESCRIPTION
CI was failing on `./bin/parse-changelog.sh` after the merging of #55. This fixes it.

I'm unsure why the Jenkins pipeline didn't execute on #55 which would have alerted us to this issue before merging it. In any case it's running now.

### Connected Issue/Story

Resolves N/A

### Definition of Done
- [x] `./bin/parse-changelog.sh` succeeds

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
