### PR TITLE
Fix Jenkins build: set corp proxy CA, git `safe.directory` config in build container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ secrets.yml
 *.sublime-project
 .idea
 *.sw[po]
+
+# Temporary directory to store the CyberArk proxy CA certificate
+build_ca_certificate/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.4.1] - 2021-05-10
 ### Added
-- Added a build for Apple Silicon [cyberark/summon-aws-secrets#55](https://github.com/cyberark/summon-aws-secrets/issues/55)
+- Added a build for Apple Silicon
+  [cyberark/summon-aws-secrets#55](https://github.com/cyberark/summon-aws-secrets/issues/55)
+
+### Changed
+- The project Golang version is updated from the end-of-life v1.13 to v1.17.
+  [cyberark/summon-aws-secrets#54](https://github.com/cyberark/summon-aws-secrets/pull/54)
 
 ## [0.4.0] - 2020-09-11
 ### Changed
@@ -34,7 +40,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/cyberark/summon-aws-secrets/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/cyberark/summon-aws-secrets/compare/v0.4.1...HEAD
+[0.4.1]: https://github.com/cyberark/summon-aws-secrets/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/cyberark/summon-aws-secrets/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/cyberark/summon-aws-secrets/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/cyberark/summon-aws-secrets/compare/v0.1.0...v0.2.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-stretch
+FROM golang:1.17-stretch
 MAINTAINER Conjur Inc
 
 # On CyberArk dev laptops, golang module dependencies are downloaded with a
@@ -22,9 +22,9 @@ RUN apt-get update && \
 
 WORKDIR /summon-aws-secrets
 
-RUN go get -u github.com/jstemmer/go-junit-report && \
-    go get -u github.com/axw/gocov/gocov && \
-    go get -u github.com/AlekSi/gocov-xml && \
+RUN go install github.com/jstemmer/go-junit-report@latest && \
+    go install github.com/axw/gocov/gocov@latest && \
+    go install github.com/AlekSi/gocov-xml@latest && \
     mkdir -p /summon-aws-secrets/output
 
 COPY go.mod go.sum /summon-aws-secrets/

--- a/Dockerfile.releaser
+++ b/Dockerfile.releaser
@@ -1,5 +1,4 @@
-FROM golang:1.16-stretch
-MAINTAINER Conjur Inc
+FROM goreleaser/goreleaser:latest
 
 # On CyberArk dev laptops, golang module dependencies are downloaded with a
 # corporate proxy in the middle. For these connections to succeed we need to
@@ -12,22 +11,5 @@ MAINTAINER Conjur Inc
 ADD build_ca_certificate /usr/local/share/ca-certificates/
 RUN update-ca-certificates
 
-ENV GOOS=linux
-ENV GOARCH=amd64
-
-EXPOSE 8080
-
-RUN apt-get update && \
-    apt-get install -y jq
-
-WORKDIR /summon-aws-secrets
-
-RUN go get -u github.com/jstemmer/go-junit-report && \
-    go get -u github.com/axw/gocov/gocov && \
-    go get -u github.com/AlekSi/gocov-xml && \
-    mkdir -p /summon-aws-secrets/output
-
-COPY go.mod go.sum /summon-aws-secrets/
-RUN go mod download
-
-COPY . .
+# Workaround for CVE-2022-24765 when running git inside a docker container
+RUN git config --global --add safe.directory /summon-aws-secrets

--- a/bin/build
+++ b/bin/build
@@ -1,14 +1,52 @@
 #!/bin/bash -e
 
-git fetch --tags  # jenkins does not do this automatically yet
+function main() {
+  retrieve_cyberark_ca_cert
+  build_binaries
 
-docker-compose pull goreleaser
+  # Needed for testing stages
+  goos='linux'
+  goarch='amd64'
+  cp dist/summon-aws-secrets_${goos}_${goarch}_v1/summon-aws-secrets .
+}
 
-echo "> Building and packaging binaries"
-docker-compose run --rm \
-  goreleaser release --rm-dist --snapshot
+function retrieve_cyberark_ca_cert() {
+  # On CyberArk dev laptops, golang module dependencies are downloaded with a
+  # corporate proxy in the middle. For these connections to succeed we need to
+  # configure the proxy CA certificate in build containers.
+  #
+  # To allow this script to also work on non-CyberArk laptops where the CA
+  # certificate is not available, we update container certificates based on
+  # a (potentially empty) certificate directory, rather than relying on the
+  # CA file itself.
+  mkdir -p "$(repo_root)/build_ca_certificate"
 
-# Needed for testing stages
-goos='linux'
-goarch="amd64"
-cp dist/summon-aws-secrets_${goos}_${goarch}/summon-aws-secrets .
+  # Only attempt to extract the certificate if the security
+  # command is available.
+  #
+  # The certificate file must have the .crt extension to be imported
+  # by `update-ca-certificates`.
+  if command -v security &>/dev/null
+  then
+    security find-certificate \
+      -a -c "CyberArk Enterprise Root CA" \
+      -p > build_ca_certificate/cyberark_root.crt
+  fi
+}
+
+function repo_root() {
+  git rev-parse --show-toplevel
+}
+
+function build_binaries() {
+  git fetch --tags # jenkins does not do this automatically yet
+
+  docker-compose build --pull goreleaser
+
+  echo "> Building and packaging binaries"
+  docker-compose run --rm \
+    goreleaser release --rm-dist --snapshot
+}
+
+main
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,10 @@ services:
       - .:/summon-aws-secrets
 
   goreleaser:
-    image: goreleaser/goreleaser:latest
+    build:
+      context: .
+      dockerfile: Dockerfile.releaser
+    image: summon-aws-secrets-releaser
     volumes:
       - .:/summon-aws-secrets
     working_dir: /summon-aws-secrets


### PR DESCRIPTION
### Desired Outcome

CI was failing trying to build the `summon-aws-secrets` binaries:
```
go: downloading github.com/jmespath/go-jmespath v0.4.0
error obtaining VCS status: exit status 128
     Use -buildvcs=false to disable VCS stamping.

1
script returned exit code 1
```

Enabling GoReleaser's debug logging revealed the following logs:
```
    • getting and validating git state
       • running git               args=[-c log.showSignature=false rev-parse --is-inside-work-tree]
       • git result                stderr=fatal: unsafe repository ('/summon-aws-secrets' is owned by someone else)
To add an exception for this directory, call:

      git config --global --add safe.directory /summon-aws-secrets
 stdout=
```

This is a symptom of recent git versions (>v2.35.2) offering security fixes for CVE-2022-24765 for git on multi-user machines, include Docker containers.

### Implemented Changes

- Wrap `goreleaser/goreleaser` image in custom `Dockerfile.releaser`:
  - Include CyberArk corporate proxy CA certs, so binaries can be built locally by CYBR devs
  - Apply workaround for CVE-2022-24765, calling `git config --global --add safe.directory /summon-aws-secrets`
- Update `Dockerfile` Golang version to match version in `go.mod`
- Update `CHANGELOG.md` for v0.4.1 release

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue link: [ONYX-19910](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-19910) [ONYX-19912](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-19912)

### Definition of Done

- [x] Fix `summon-aws-secret` failing CI build
- [x] Prepare for v0.4.1 release

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
