### PR TITLE
Fix goreleaser url pattern to use the right repo

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,7 +46,7 @@ archives:
 brews:
   - description: AWS Secrets Manager provider for Summon
     homepage: https://github.com/cyberark/summon-aws-secrets
-    url_template: https://github.com/cyberark/summon/releases/download/v{{.Version}}/summon-aws-secrets-{{ tolower .Os }}-{{ tolower .Arch }}.tar.gz
+    url_template: https://github.com/cyberark/summon-aws-secrets/releases/download/v{{.Version}}/summon-aws-secrets-{{ tolower .Os }}-{{ tolower .Arch }}.tar.gz
     install: |
       target = lib/"summon"
       target.install "summon-aws-secrets"


### PR DESCRIPTION
### Desired Outcome

Homebrew formula should have the right download url.

### Implemented Changes

The URL patter in the goreleaser config referred to the wrong repo. It ws cyberark/summon but should have been cyberark/summon-aws-secrets. This meant that the homebrew formula had an invalid download URL.

- _What's changed? Why were these changes made?_

Updated URL template for homebrew formulas

- _How should the reviewer approach this PR, especially if manual tests are required?_

I don't use goreleaser, so I'm not sure how to test this, but I believe it's a safe change since the repo name is correct now and it definitely didn't work before.

- _Are there relevant screenshots you can add to the PR description?_

Nope.

### Connected Issue/Story

Resolves https://github.com/cyberark/homebrew-tools/issues/49

CyberArk internal issue link: [insert issue ID]()

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
