### PR TITLE
Prune old version of gopkg.in/yaml.v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Security
+- Prune old versions of gopkg.in/yaml.v3
+  [cyberark/summon-aws-secrets#66](https://github.com/cyberark/summon-aws-secrets/pull/66)
 - Updated dependencies (aws-sdk-go -> v1.44.106, testify -> 1.8.0) and added replace
   to force golang.org/x/net to latest version for CVE-2022-27664
   [cyberark/summon-aws-secrets#65](https://github.com/cyberark/summon-aws-secrets/pull/65)

--- a/go.mod
+++ b/go.mod
@@ -15,3 +15,5 @@ require (
 go 1.18
 
 replace golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd => golang.org/x/net v0.0.0-20220923203811-8be639271d50
+
+replace gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c => gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
Signed-off-by: Andy Tinkham <andy.tinkham@cyberark.com>

### Desired Outcome

Prune old version of gopkg.in/yaml.v3. We already used a newer one so weren't vulnerable to the issues in the older version, but this removes it entirely from consideration.

### Implemented Changes

Added replace statement to force v3.0.1

